### PR TITLE
[fix] 공유받기 ssid라벨 height조절

### DIFF
--- a/Wasap/Wasap/Features/WifiAutoConnect/View/ReceivingView.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/View/ReceivingView.swift
@@ -77,8 +77,8 @@ class ReceivingView: BaseView {
         backgroundView.snp.makeConstraints { $0.edges.equalToSuperview() }
 
         loadingAnimation.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(33)
             $0.centerX.equalToSuperview()
-            $0.bottom.equalTo(ssidLabel.snp.top).offset(2)
         }
 
         xButton.snp.makeConstraints {
@@ -89,8 +89,9 @@ class ReceivingView: BaseView {
 
         ssidLabel.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.bottom.equalTo(subLabel.snp.top).offset(-15)
+            $0.bottom.equalTo(subLabel.snp.top).offset(-11)
             $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(30)
         }
 
         subLabel.snp.makeConstraints {


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
공유받기 ssid 라벨 부분의 height를 조절하여 g, j와 같은 몇몇 소문자의 아래가 잘리는 문제를 해결합니다.

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #99 


## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

