### PR TITLE
[fix] 아이폰 pro max 사이즈 대비 레이아웃 조정

### DIFF
--- a/Wasap/Wasap/Features/WifiAutoConnect/View/GoToSettingView.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/View/GoToSettingView.swift
@@ -237,80 +237,85 @@ class GoToSettingView: BaseView {
     }
 
     func setConstraints() {
+        let screenHeight = UIScreen.main.bounds.height // 화면 높이
+        let screenWidth = UIScreen.main.bounds.width  // 화면 너비
+
         backgroundView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
 
         cameraButton.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(68)
-            $0.trailing.equalToSuperview().inset(24)
-            $0.width.height.equalTo(32)
+            $0.top.equalToSuperview().offset(68/852 * screenHeight)
+            $0.trailing.equalToSuperview().inset(24/393 * screenWidth)
+            $0.width.equalTo(32/393 * screenWidth)
+            $0.height.equalTo(32/852 * screenHeight)
         }
 
         titleStackView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(116)
-            $0.leading.trailing.equalToSuperview().inset(24)
-            $0.height.equalTo(59)
+            $0.top.equalToSuperview().offset(116/852 * screenHeight)
+            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
+            $0.height.equalTo(59/852 * screenHeight)
         }
 
         memoView.snp.makeConstraints {
-            $0.top.equalTo(titleStackView.snp.bottom).offset(50)
-            $0.leading.trailing.equalToSuperview().inset(24)
-            $0.height.equalTo(221)
+            $0.top.equalTo(titleStackView.snp.bottom).offset(50/852 * screenHeight)
+            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
+            $0.height.equalTo(221/852 * screenHeight)
         }
 
         infoIcon.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(14)
-            $0.trailing.equalToSuperview().inset(16)
-            $0.width.height.equalTo(16)
+            $0.top.equalToSuperview().inset(14/852 * screenHeight)
+            $0.trailing.equalToSuperview().inset(16/393 * screenWidth)
+            $0.width.equalTo(16/393 * screenWidth)
+            $0.height.equalTo(16/852 * screenHeight)
         }
 
         memoText.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(32)
-            $0.leading.trailing.equalToSuperview().inset(16)
-            $0.height.equalTo(26)
-            $0.width.equalTo(81)
+            $0.top.equalToSuperview().inset(32/852 * screenHeight)
+            $0.leading.trailing.equalToSuperview().inset(16/393 * screenWidth)
+            $0.height.equalTo(26/852 * screenHeight)
+            $0.width.equalTo(81/393 * screenWidth)
         }
 
         ssidStackView.snp.makeConstraints{
-            $0.top.equalTo(memoText.snp.bottom).offset(16)
-            $0.leading.trailing.equalToSuperview().inset(16)
-            $0.height.equalTo(48)
+            $0.top.equalTo(memoText.snp.bottom).offset(16/852 * screenHeight)
+            $0.leading.trailing.equalToSuperview().inset(16/393 * screenWidth)
+            $0.height.equalTo(48/852 * screenHeight)
         }
 
         pwStackView.snp.makeConstraints {
-            $0.top.equalTo(ssidStackView.snp.bottom).offset(20)
-            $0.leading.equalToSuperview().inset(16)
-            $0.height.equalTo(48)
-            $0.width.equalTo(220)
+            $0.top.equalTo(ssidStackView.snp.bottom).offset(20/852 * screenHeight)
+            $0.leading.equalToSuperview().inset(16/393 * screenWidth)
+            $0.height.equalTo(48/852 * screenHeight)
+            $0.width.equalTo(220/393 * screenWidth)
         }
 
         copyButton.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(16)
-            $0.bottom.equalToSuperview().inset(27)
-            $0.width.equalTo(84)
-            $0.height.equalTo(38)
+            $0.trailing.equalToSuperview().inset(16/393 * screenWidth)
+            $0.bottom.equalToSuperview().inset(27/852 * screenHeight)
+            $0.width.equalTo(84/393 * screenWidth)
+            $0.height.equalTo(38/852 * screenHeight)
         }
 
         infoStackView.snp.makeConstraints {
-            $0.top.equalTo(memoView.snp.bottom).offset(177)
-            $0.leading.trailing.equalToSuperview().inset(24)
-            $0.height.equalTo(52)
-            $0.width.equalTo(320)
+            $0.top.equalTo(memoView.snp.bottom).offset(177/852 * screenHeight)
+            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
+            $0.height.equalTo(52/852 * screenHeight)
+            $0.width.equalTo(320/393 * screenWidth)
         }
 
         btnStackView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(24)
-            $0.top.equalTo(infoStackView.snp.bottom).offset(50)
-            $0.height.equalTo(52)
+            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
+            $0.bottom.equalToSuperview().offset(-83/852 * screenHeight)
+            $0.height.equalTo(52/852 * screenHeight)
         }
 
         backButton.snp.makeConstraints {
-            $0.width.equalTo(99)
+            $0.width.equalTo(99/393 * screenWidth)
         }
 
         settingButton.snp.makeConstraints {
-            $0.width.equalTo(236)
+            $0.width.equalTo(236/393 * screenWidth)
         }
     }
 

--- a/Wasap/Wasap/Features/WifiAutoConnect/View/GoToSettingView.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/View/GoToSettingView.swift
@@ -237,85 +237,80 @@ class GoToSettingView: BaseView {
     }
 
     func setConstraints() {
-        let screenHeight = UIScreen.main.bounds.height // 화면 높이
-        let screenWidth = UIScreen.main.bounds.width  // 화면 너비
-
         backgroundView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
 
         cameraButton.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(68/852 * screenHeight)
-            $0.trailing.equalToSuperview().inset(24/393 * screenWidth)
-            $0.width.equalTo(32/393 * screenWidth)
-            $0.height.equalTo(32/852 * screenHeight)
+            $0.top.equalToSuperview().offset(68)
+            $0.trailing.equalToSuperview().inset(24)
+            $0.width.height.equalTo(32)
         }
 
         titleStackView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(116/852 * screenHeight)
-            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
-            $0.height.equalTo(59/852 * screenHeight)
+            $0.top.equalToSuperview().offset(116)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.height.equalTo(59)
         }
 
         memoView.snp.makeConstraints {
-            $0.top.equalTo(titleStackView.snp.bottom).offset(50/852 * screenHeight)
-            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
-            $0.height.equalTo(221/852 * screenHeight)
+            $0.top.equalTo(titleStackView.snp.bottom).offset(50)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.height.equalTo(221)
         }
 
         infoIcon.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(14/852 * screenHeight)
-            $0.trailing.equalToSuperview().inset(16/393 * screenWidth)
-            $0.width.equalTo(16/393 * screenWidth)
-            $0.height.equalTo(16/852 * screenHeight)
+            $0.top.equalToSuperview().inset(14)
+            $0.trailing.equalToSuperview().inset(16)
+            $0.width.height.equalTo(16)
         }
 
         memoText.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(32/852 * screenHeight)
-            $0.leading.trailing.equalToSuperview().inset(16/393 * screenWidth)
-            $0.height.equalTo(26/852 * screenHeight)
-            $0.width.equalTo(81/393 * screenWidth)
+            $0.top.equalToSuperview().inset(32)
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.height.equalTo(26)
+            $0.width.equalTo(81)
         }
 
         ssidStackView.snp.makeConstraints{
-            $0.top.equalTo(memoText.snp.bottom).offset(16/852 * screenHeight)
-            $0.leading.trailing.equalToSuperview().inset(16/393 * screenWidth)
-            $0.height.equalTo(48/852 * screenHeight)
+            $0.top.equalTo(memoText.snp.bottom).offset(16)
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.height.equalTo(48)
         }
 
         pwStackView.snp.makeConstraints {
-            $0.top.equalTo(ssidStackView.snp.bottom).offset(20/852 * screenHeight)
-            $0.leading.equalToSuperview().inset(16/393 * screenWidth)
-            $0.height.equalTo(48/852 * screenHeight)
-            $0.width.equalTo(220/393 * screenWidth)
+            $0.top.equalTo(ssidStackView.snp.bottom).offset(20)
+            $0.leading.equalToSuperview().inset(16)
+            $0.height.equalTo(48)
+            $0.width.equalTo(220)
         }
 
         copyButton.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(16/393 * screenWidth)
-            $0.bottom.equalToSuperview().inset(27/852 * screenHeight)
-            $0.width.equalTo(84/393 * screenWidth)
-            $0.height.equalTo(38/852 * screenHeight)
+            $0.trailing.equalToSuperview().inset(16)
+            $0.bottom.equalToSuperview().inset(27)
+            $0.width.equalTo(84)
+            $0.height.equalTo(38)
         }
 
         infoStackView.snp.makeConstraints {
-            $0.top.equalTo(memoView.snp.bottom).offset(177/852 * screenHeight)
-            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
-            $0.height.equalTo(52/852 * screenHeight)
-            $0.width.equalTo(320/393 * screenWidth)
+            $0.top.equalTo(memoView.snp.bottom).offset(177)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.height.equalTo(52)
+            $0.width.equalTo(320)
         }
 
         btnStackView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
-            $0.bottom.equalToSuperview().offset(-83/852 * screenHeight)
-            $0.height.equalTo(52/852 * screenHeight)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.top.equalTo(infoStackView.snp.bottom).offset(50)
+            $0.height.equalTo(52)
         }
 
         backButton.snp.makeConstraints {
-            $0.width.equalTo(99/393 * screenWidth)
+            $0.width.equalTo(99)
         }
 
         settingButton.snp.makeConstraints {
-            $0.width.equalTo(236/393 * screenWidth)
+            $0.width.equalTo(236)
         }
     }
 

--- a/Wasap/Wasap/Features/WifiAutoConnect/View/WifiReConnectView.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/View/WifiReConnectView.swift
@@ -164,25 +164,30 @@ class WifiReConnectView: BaseView {
     }
 
     func setConstraints() {
+
+        let screenHeight = UIScreen.main.bounds.height // 화면 높이
+        let screenWidth = UIScreen.main.bounds.width  // 화면 너비
+
         backgroundView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
 
         cameraButton.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(24)
-            $0.bottom.equalTo(labelStackView.snp.top).offset(-16)
-            $0.width.height.equalTo(32)
+            $0.bottom.equalTo(labelStackView.snp.top).offset(-16/852 * screenHeight)
+            $0.trailing.equalToSuperview().inset(24/393 * screenWidth)
+            $0.width.equalTo(32/393 * screenWidth)
+            $0.height.equalTo(32/852 * screenHeight)
         }
 
         labelStackView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(24)
-            $0.bottom.equalTo(photoImageView.snp.top).offset(-50)
+            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
+            $0.bottom.equalTo(photoImageView.snp.top).offset(-50/852 * screenHeight)
         }
 
         photoContainerView.snp.makeConstraints {
-                $0.leading.trailing.equalToSuperview().inset(24)
-                $0.bottom.equalTo(ssidStackView.snp.top).offset(-29)
-                $0.height.equalTo(224)
+            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
+            $0.bottom.equalTo(ssidStackView.snp.top).offset(-29/852 * screenHeight)
+            $0.height.equalTo(224/852 * screenHeight)
             }
 
         photoImageView.snp.makeConstraints { make in
@@ -190,42 +195,35 @@ class WifiReConnectView: BaseView {
         }
 
         ssidStackView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(24)
-            $0.bottom.equalTo(pwStackView.snp.top).offset(-8)
-            $0.height.equalTo(86)
+            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
+            $0.bottom.equalTo(pwStackView.snp.top).offset(-8/852 * screenHeight)
+            $0.height.equalTo(86/852 * screenHeight)
         }
 
         ssidField.snp.makeConstraints {
-            $0.height.equalTo(60)
-            $0.width.equalTo(345)
+            $0.height.equalTo(60/852 * screenHeight)
+            $0.width.equalTo(345/393 * screenWidth)
         }
 
         pwStackView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(24)
-            $0.bottom.equalTo(self.keyboardLayoutGuide.snp.top).offset(-197)
-            $0.height.equalTo(86)
+            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
+            $0.bottom.equalTo(self.keyboardLayoutGuide.snp.top).offset(-197/852 * screenHeight)
+            $0.height.equalTo(86/852 * screenHeight)
         }
 
         pwField.snp.makeConstraints {
-            $0.height.equalTo(60)
-            $0.width.equalTo(345)
+            $0.height.equalTo(60/852 * screenHeight)
+            $0.width.equalTo(345/393 * screenWidth)
         }
 
         reConnectButton.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(24)
-            $0.bottom.equalToSuperview().offset(-83)
-            $0.height.equalTo(52)
+            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
+            $0.bottom.equalToSuperview().offset(-83/852 * screenHeight)
+            $0.height.equalTo(52/852 * screenHeight)
         }
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
-
-//        photoContainerView.applyShadow(
-//            offset: CGSize(width: 0, height: 4),
-//            radius: 4,
-//            color: .black,
-//            opacity: 0.25
-//        )
     }
 }

--- a/Wasap/Wasap/Features/WifiAutoConnect/View/WifiReConnectView.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/View/WifiReConnectView.swift
@@ -184,6 +184,10 @@ class WifiReConnectView: BaseView {
             $0.bottom.equalTo(photoImageView.snp.top).offset(-50/852 * screenHeight)
         }
 
+        subLabel.snp.makeConstraints {
+            $0.height.equalTo(26/852 * screenHeight)
+        }
+
         photoContainerView.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
             $0.bottom.equalTo(ssidStackView.snp.top).offset(-29/852 * screenHeight)

--- a/Wasap/Wasap/Features/WifiAutoConnect/View/WifiReConnectView.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/View/WifiReConnectView.swift
@@ -164,30 +164,25 @@ class WifiReConnectView: BaseView {
     }
 
     func setConstraints() {
-
-        let screenHeight = UIScreen.main.bounds.height // 화면 높이
-        let screenWidth = UIScreen.main.bounds.width  // 화면 너비
-
         backgroundView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
 
         cameraButton.snp.makeConstraints {
-            $0.bottom.equalTo(labelStackView.snp.top).offset(-16/852 * screenHeight)
-            $0.trailing.equalToSuperview().inset(24/393 * screenWidth)
-            $0.width.equalTo(32/393 * screenWidth)
-            $0.height.equalTo(32/852 * screenHeight)
+            $0.trailing.equalToSuperview().inset(24)
+            $0.bottom.equalTo(labelStackView.snp.top).offset(-16)
+            $0.width.height.equalTo(32)
         }
 
         labelStackView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
-            $0.bottom.equalTo(photoImageView.snp.top).offset(-50/852 * screenHeight)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.bottom.equalTo(photoImageView.snp.top).offset(-50)
         }
 
         photoContainerView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
-            $0.bottom.equalTo(ssidStackView.snp.top).offset(-29/852 * screenHeight)
-            $0.height.equalTo(224/852 * screenHeight)
+                $0.leading.trailing.equalToSuperview().inset(24)
+                $0.bottom.equalTo(ssidStackView.snp.top).offset(-29)
+                $0.height.equalTo(224)
             }
 
         photoImageView.snp.makeConstraints { make in
@@ -195,35 +190,42 @@ class WifiReConnectView: BaseView {
         }
 
         ssidStackView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
-            $0.bottom.equalTo(pwStackView.snp.top).offset(-8/852 * screenHeight)
-            $0.height.equalTo(86/852 * screenHeight)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.bottom.equalTo(pwStackView.snp.top).offset(-8)
+            $0.height.equalTo(86)
         }
 
         ssidField.snp.makeConstraints {
-            $0.height.equalTo(60/852 * screenHeight)
-            $0.width.equalTo(345/393 * screenWidth)
+            $0.height.equalTo(60)
+            $0.width.equalTo(345)
         }
 
         pwStackView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
-            $0.bottom.equalTo(self.keyboardLayoutGuide.snp.top).offset(-197/852 * screenHeight)
-            $0.height.equalTo(86/852 * screenHeight)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.bottom.equalTo(self.keyboardLayoutGuide.snp.top).offset(-197)
+            $0.height.equalTo(86)
         }
 
         pwField.snp.makeConstraints {
-            $0.height.equalTo(60/852 * screenHeight)
-            $0.width.equalTo(345/393 * screenWidth)
+            $0.height.equalTo(60)
+            $0.width.equalTo(345)
         }
 
         reConnectButton.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
-            $0.bottom.equalToSuperview().offset(-83/852 * screenHeight)
-            $0.height.equalTo(52/852 * screenHeight)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.bottom.equalToSuperview().offset(-83)
+            $0.height.equalTo(52)
         }
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
+
+//        photoContainerView.applyShadow(
+//            offset: CGSize(width: 0, height: 4),
+//            radius: 4,
+//            color: .black,
+//            opacity: 0.25
+//        )
     }
 }

--- a/Wasap/Wasap/Features/WifiAutoConnect/ViewController/WifiReConnectViewController.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/ViewController/WifiReConnectViewController.swift
@@ -89,7 +89,7 @@ public class WifiReConnectViewController: RxBaseViewController<WifiReConnectView
                 UIView.animate(withDuration: 0.15) {
                     self?.wifiReConnectView.reConnectButton.transform = CGAffineTransform(scaleX: 1, y: 0.95)
                     self?.wifiReConnectView.reConnectButton.setTitleColor(.black, for: .normal)
-                    self?.wifiReConnectView.reConnectButton.backgroundColor = .green200
+                    self?.wifiReConnectView.reConnectButton.backgroundColor = .green300
 
                     self?.wifiReConnectView.reConnectButton.layer.borderWidth = 1
                     self?.wifiReConnectView.reConnectButton.layer.borderColor = UIColor.clear.cgColor
@@ -247,13 +247,10 @@ public class WifiReConnectViewController: RxBaseViewController<WifiReConnectView
 
     // MARK: 키보드 보일 때 처리
     private func handleKeyboardWillShow() {
-        let screenHeight = UIScreen.main.bounds.height // 화면 높이
-        let screenWidth = UIScreen.main.bounds.width  // 화면 너비
-
         wifiReConnectView.pwStackView.snp.remakeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
-            $0.bottom.equalTo(self.view.keyboardLayoutGuide.snp.top).offset(-20/852 * screenHeight)
-            $0.height.equalTo(86/852 * screenHeight)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.bottom.equalTo(self.view.keyboardLayoutGuide.snp.top).offset(-20)
+            $0.height.equalTo(86)
         }
 
         UIView.animate(withDuration: 0.1, delay: 0, options: [.curveEaseInOut], animations: {
@@ -266,14 +263,12 @@ public class WifiReConnectViewController: RxBaseViewController<WifiReConnectView
 
     // MARK: 키보드 숨길 때 처리
     private func handleKeyboardWillHide() {
-        let screenHeight = UIScreen.main.bounds.height // 화면 높이
-        let screenWidth = UIScreen.main.bounds.width  // 화면 너비
         resetViewState()
 
         wifiReConnectView.pwStackView.snp.remakeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
-            $0.bottom.equalTo(self.view.keyboardLayoutGuide.snp.top).offset(-197/852 * screenHeight)
-            $0.height.equalTo(86/852 * screenHeight)
+            $0.leading.trailing.equalToSuperview().inset(24)
+            $0.bottom.equalTo(self.view.keyboardLayoutGuide.snp.top).offset(-197)
+            $0.height.equalTo(86)
         }
 
         UIView.animate(withDuration: 0.1, delay: 0, options: [.curveEaseInOut], animations: {

--- a/Wasap/Wasap/Features/WifiAutoConnect/ViewController/WifiReConnectViewController.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/ViewController/WifiReConnectViewController.swift
@@ -89,7 +89,7 @@ public class WifiReConnectViewController: RxBaseViewController<WifiReConnectView
                 UIView.animate(withDuration: 0.15) {
                     self?.wifiReConnectView.reConnectButton.transform = CGAffineTransform(scaleX: 1, y: 0.95)
                     self?.wifiReConnectView.reConnectButton.setTitleColor(.black, for: .normal)
-                    self?.wifiReConnectView.reConnectButton.backgroundColor = .green300
+                    self?.wifiReConnectView.reConnectButton.backgroundColor = .green200
 
                     self?.wifiReConnectView.reConnectButton.layer.borderWidth = 1
                     self?.wifiReConnectView.reConnectButton.layer.borderColor = UIColor.clear.cgColor
@@ -247,10 +247,13 @@ public class WifiReConnectViewController: RxBaseViewController<WifiReConnectView
 
     // MARK: 키보드 보일 때 처리
     private func handleKeyboardWillShow() {
+        let screenHeight = UIScreen.main.bounds.height // 화면 높이
+        let screenWidth = UIScreen.main.bounds.width  // 화면 너비
+
         wifiReConnectView.pwStackView.snp.remakeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(24)
-            $0.bottom.equalTo(self.view.keyboardLayoutGuide.snp.top).offset(-20)
-            $0.height.equalTo(86)
+            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
+            $0.bottom.equalTo(self.view.keyboardLayoutGuide.snp.top).offset(-20/852 * screenHeight)
+            $0.height.equalTo(86/852 * screenHeight)
         }
 
         UIView.animate(withDuration: 0.1, delay: 0, options: [.curveEaseInOut], animations: {
@@ -263,12 +266,14 @@ public class WifiReConnectViewController: RxBaseViewController<WifiReConnectView
 
     // MARK: 키보드 숨길 때 처리
     private func handleKeyboardWillHide() {
+        let screenHeight = UIScreen.main.bounds.height // 화면 높이
+        let screenWidth = UIScreen.main.bounds.width  // 화면 너비
         resetViewState()
 
         wifiReConnectView.pwStackView.snp.remakeConstraints {
-            $0.leading.trailing.equalToSuperview().inset(24)
-            $0.bottom.equalTo(self.view.keyboardLayoutGuide.snp.top).offset(-197)
-            $0.height.equalTo(86)
+            $0.leading.trailing.equalToSuperview().inset(24/393 * screenWidth)
+            $0.bottom.equalTo(self.view.keyboardLayoutGuide.snp.top).offset(-197/852 * screenHeight)
+            $0.height.equalTo(86/852 * screenHeight)
         }
 
         UIView.animate(withDuration: 0.1, delay: 0, options: [.curveEaseInOut], animations: {


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->

- [x] pro max 사이즈 화면 일 경우 레이아웃 위치가 바뀌는 문제를 해결했습니다.

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #105


## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
iPhone 15 pro 사이즈 기준으로  height : 852, width: 393 으로 설정 되어 있는 부분을 반영하여 제약을 줄 때 
->`[(제약) / (세로: 852 px or 가로: 393 px ) X 현재 전체 화면 사이즈 ]` 방식을 이용하여 사이즈 별 레이아웃 문제를 대응하였습니다. 

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

