### PR TITLE
[fix] 공유받기 버튼텍스트 및 QR 위치값 수정

### DIFF
--- a/Wasap/Wasap/Features/WifiAutoConnect/View/ReceivingView.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/View/ReceivingView.swift
@@ -59,7 +59,6 @@ class ReceivingView: BaseView {
         button.setTitle("바로 연결하기".localized(), for: .normal)
         button.setTitleColor(.textPrimaryHigh, for: .normal)
         button.titleLabel?.font = .tg16
-        button.titleLabel?.addLabelSpacing(fontStyle: .tg16)
         button.backgroundColor = .neutral500
 
         button.layer.cornerRadius = 25

--- a/Wasap/Wasap/Features/WifiAutoConnect/View/SharingQRView.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/View/SharingQRView.swift
@@ -74,14 +74,14 @@ class SharingQRView: BaseView {
 
         titleLabel.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.bottom.equalTo(qrCodeView.snp.top).offset(-34)
+            $0.top.equalToSuperview().offset(147)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(25)
         }
 
         qrCodeView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.bottom.equalTo(closeButton.snp.top).offset(-153)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(34)
             $0.width.equalTo(287)
             $0.height.equalTo(287)
         }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
공유받기 버튼의 텍스트를 중앙 정렬하고, QR 공유하기에서의 QR코드 위치를 Max 기기 대응을 위해 top으로 조정합니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #113 


## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
공유받기 버튼의 텍스트에 label spacing 적용을 뺐습니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

