### PR TITLE
[fix] 사진 orientation 값 반영

### DIFF
--- a/Wasap/Wasap/Features/WifiAutoConnect/Repository/CameraRepository.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/Repository/CameraRepository.swift
@@ -303,9 +303,29 @@ extension DefaultCameraRepository: AVCaptureVideoDataOutputSampleBufferDelegate 
             return
         }
 
+        let orientation = self.imageOrientation(from: UIDevice.current.orientation)
+
         // CVPixelBuffer를 CIImage로 변환
         let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
-        self.capturedVideoDataStream.onNext(UIImage(ciImage: ciImage))
+
+        self.capturedVideoDataStream.onNext(UIImage(ciImage: ciImage, scale: 1.0, orientation: orientation))
+    }
+
+    private func imageOrientation(from deviceOrientation: UIDeviceOrientation) -> UIImage.Orientation {
+        switch deviceOrientation {
+        case .portrait:
+            return .right
+        case .portraitUpsideDown:
+            return .left
+        case .landscapeLeft:
+            return .up
+        case .landscapeRight:
+            return .down
+        case .faceUp, .faceDown, .unknown:
+            return .up // 기본값
+        @unknown default:
+            return .up
+        }
     }
 }
 

--- a/Wasap/Wasap/Features/WifiAutoConnect/ViewModel/CameraViewModel.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/ViewModel/CameraViewModel.swift
@@ -227,10 +227,20 @@ public class CameraViewModel: BaseViewModel {
                 }
 
                 let convertedSSIDRect = ocrResult.ssidBoundingBox.map { box in
-                    videoPreviewLayer.layerRectConverted(fromMetadataOutputRect: box)
+                    let rotatedX = box.minY
+                    let rotatedY = 1.0 - box.maxX
+                    let rotatedWidth = box.height
+                    let rotatedHeight = box.width
+                    let rect = CGRect(x: rotatedX, y: rotatedY, width: rotatedWidth, height: rotatedHeight)
+                    return videoPreviewLayer.layerRectConverted(fromMetadataOutputRect: rect)
                 }
                 let convertedPasswordRect = ocrResult.passwordBoundingBox.map { box in
-                    videoPreviewLayer.layerRectConverted(fromMetadataOutputRect: box)
+                    let rotatedX = box.minY
+                    let rotatedY = 1.0 - box.maxX
+                    let rotatedWidth = box.height
+                    let rotatedHeight = box.width
+                    let rect = CGRect(x: rotatedX, y: rotatedY, width: rotatedWidth, height: rotatedHeight)
+                    return videoPreviewLayer.layerRectConverted(fromMetadataOutputRect: rect)
                 }
 
                 ssidRelay.accept(convertedSSIDRect)


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
원래 image 분석 시 90도 돌아간 카메라를 분석했던 이슈를 수정.

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #121


## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
분석 완료 된 boundingBox까지는 방향이 맞지만, layerRectConverted 함수에 넣으면 90도가 돌아갑니다. 따라서 box를 반대로 90도 회전시킨 값을 layerRectConverted 함수로 넣어서 방향을 맞추어었습니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

https://github.com/user-attachments/assets/214afc24-0a44-49eb-8ffb-9c01128293eb


