### PR TITLE
[refactor] SSID/PW 판별에 Regex 도입 및 키워드 없는 경우 대응

### DIFF
--- a/Wasap/Wasap/DIContainer/AppDIContainer.swift
+++ b/Wasap/Wasap/DIContainer/AppDIContainer.swift
@@ -29,9 +29,11 @@ final public class WifiAutoConnectDIContainer {
         return DefaultImageAnalysisRepository()
     }
 
-//    public func makeQuickImageAnalysisRepository() -> ImageAnalysisRepository {
-//        return QuickImageAnalysisRepository()
-//    }
+    /**
+    public func makeQuickImageAnalysisRepository() -> ImageAnalysisRepository {
+        return QuickImageAnalysisRepository()
+    }
+    */
 
     public func makeWiFiConnectRepository() -> WiFiConnectRepository {
         return defaultWiFiConnectRepository

--- a/Wasap/Wasap/DIContainer/AppDIContainer.swift
+++ b/Wasap/Wasap/DIContainer/AppDIContainer.swift
@@ -29,9 +29,9 @@ final public class WifiAutoConnectDIContainer {
         return DefaultImageAnalysisRepository()
     }
 
-    public func makeQuickImageAnalysisRepository() -> ImageAnalysisRepository {
-        return QuickImageAnalysisRepository()
-    }
+//    public func makeQuickImageAnalysisRepository() -> ImageAnalysisRepository {
+//        return QuickImageAnalysisRepository()
+//    }
 
     public func makeWiFiConnectRepository() -> WiFiConnectRepository {
         return defaultWiFiConnectRepository

--- a/Wasap/Wasap/Entity/ImageAnalysisResult.swift
+++ b/Wasap/Wasap/Entity/ImageAnalysisResult.swift
@@ -24,8 +24,8 @@ public struct KeywordBox {
     let label: String
     let content: String
     let contentBox: CGRect
-    let labelBox: CGRect
-    let index: Int?
+    let keyword: String?
+    let keywordBox: CGRect?
 }
 
 struct ExtractedBoxes {

--- a/Wasap/Wasap/Features/WifiAutoConnect/Repository/ImageAnalysisRepository.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/Repository/ImageAnalysisRepository.swift
@@ -14,8 +14,8 @@ public protocol ImageAnalysisRepository {
 }
 
 public final class DefaultImageAnalysisRepository: ImageAnalysisRepository {
-    let idKeywords: [String] = ["ssid", "SSID", "ID", "Id", "iD", "id", "I/D", "I.D", "1D", "1.D", "아이디", "1b", "이름", "무선랜 이름", "무선랜이름", "1.0", "10", "Network", "NETWORK", "network", "네트워크",  "WIFI", "Wifi", "WiFi", "wifi", "Wi-Fi", "와이파이"]
-    let pwKeywords: [String] = ["PW", "Pw", "pW", "pw", "pass", "Pass", "PASS", "password", "Password", "PASSWORD", "패스워드", "암호", "무선랜 암호", "무선랜암호", "P.W", "PV", "P/W", "P\\A", "P1A", "비밀번호", "비번"]
+//    let idKeywords: [String] = ["ssid", "SSID", "ID", "Id", "iD", "id", "I/D", "I.D", "1D", "1.D", "아이디", "1b", "이름", "무선랜 이름", "무선랜이름", "1.0", "10", "Network", "NETWORK", "network", "네트워크",  "WIFI", "Wifi", "WiFi", "wifi", "Wi-Fi", "와이파이"]
+//    let pwKeywords: [String] = ["PW", "Pw", "pW", "pw", "pass", "Pass", "PASS", "password", "Password", "PASSWORD", "패스워드", "암호", "무선랜 암호", "무선랜암호", "P.W", "PV", "P/W", "P\\A", "P1A", "비밀번호", "비번"]
 
     public init() {}
 
@@ -79,7 +79,7 @@ public final class DefaultImageAnalysisRepository: ImageAnalysisRepository {
         var ssidBox: (CGRect, String)?
         if let firstIDBox = extractedBoxes.idBoxes.first {
             if firstIDBox.content.isEmpty {
-                ssidBox = findClosestRightText(for: extractedBoxes.idBoxes.map { $0.labelBox }, in: extractedBoxes.otherBoxes)
+                ssidBox = findClosestRightText(for: extractedBoxes.idBoxes.map { $0.keywordBox ?? $0.contentBox }, in: extractedBoxes.otherBoxes)
             } else {
                 ssidBox = (firstIDBox.contentBox, firstIDBox.content)
             }
@@ -88,18 +88,29 @@ public final class DefaultImageAnalysisRepository: ImageAnalysisRepository {
         var passwordBox: (CGRect, String)?
         if let firstPWBox = extractedBoxes.pwBoxes.first {
             if firstPWBox.content.isEmpty {
-                passwordBox = findClosestRightText(for: extractedBoxes.pwBoxes.map { $0.labelBox }, in: extractedBoxes.otherBoxes)
+                passwordBox = findClosestRightText(for: extractedBoxes.pwBoxes.map { $0.keywordBox ?? $0.contentBox }, in: extractedBoxes.otherBoxes)
             } else {
                 passwordBox = (firstPWBox.contentBox, firstPWBox.content)
             }
+        } else if ssidBox != nil && ssidBox?.1 != "" {
+            passwordBox = findClosestBelowText(for: [ssidBox!.0], in: extractedBoxes.otherBoxes)
+            print("other:\(extractedBoxes.otherBoxes.first?.1)")
+            print("🐰ssidBox1:\(ssidBox?.1)")
+            print("🐰ssidBox0:\(ssidBox?.0)")
+            print("🥝passwordBox:\(passwordBox?.1)")
         }
 
         // 2. ID(또는 PW) key와 value가 세로로 나란한 경우
         if (ssidBox == nil) || (ssidBox?.1 == "") {
-            ssidBox = findClosestBelowText(for: extractedBoxes.idBoxes.map { $0.labelBox }, in: extractedBoxes.otherBoxes)
+            ssidBox = findClosestBelowText(for: extractedBoxes.idBoxes.map { $0.keywordBox ?? $0.contentBox }, in: extractedBoxes.otherBoxes)
         }
         if (passwordBox == nil) || (passwordBox?.1 == "") {
-            passwordBox = findClosestBelowText(for: extractedBoxes.pwBoxes.map { $0.labelBox }, in: extractedBoxes.otherBoxes)
+            passwordBox = findClosestBelowText(for: extractedBoxes.pwBoxes.map { $0.keywordBox ?? $0.contentBox }, in: extractedBoxes.otherBoxes)
+            if let ssidBox = ssidBox {
+                if (passwordBox == nil || passwordBox?.1 == "") && ssidBox.1 != "" {
+                    passwordBox = findClosestBelowText(for: [ssidBox.0], in: extractedBoxes.otherBoxes)
+                }
+            }
         }
 
         let delimiters = CharacterSet(charactersIn: "/,")
@@ -129,81 +140,149 @@ public final class DefaultImageAnalysisRepository: ImageAnalysisRepository {
             let originalText = topCandidate.string
             let boundingBox = observation.boundingBox
 
-            let keywordBox = self.identifyKeyword(originalText: originalText, boundingBox: boundingBox)
+            let keywordBoxes = self.identifyKeyword(originalText: originalText, boundingBox: boundingBox)
 
-            switch keywordBox.label {
-            case "ID":
-                idBoxes.append(keywordBox)
-            case "PW":
-                pwBoxes.append(keywordBox)
-            default:
-                otherBoxes.append((keywordBox.contentBox, keywordBox.content))
-
+            for keywordBox in keywordBoxes {
+                switch keywordBox.label {
+                case "ID":
+                    idBoxes.append(keywordBox)
+                case "PW":
+                    pwBoxes.append(keywordBox)
+                default:
+                    otherBoxes.append((keywordBox.contentBox, keywordBox.content))
+                }
             }
         }
 
-        idBoxes.sort { $0.index! < $1.index! }
-        pwBoxes.sort { $0.index! < $1.index! }
+//        idBoxes.sort { $0.keyword! < $1.keyword! }
+//        pwBoxes.sort { $0.keyword! < $1.keyword! }
+
+        idBoxes.sort {
+            if $0.keyword! == $1.keyword! {
+                return !$0.content.isEmpty && $1.content.isEmpty
+            }
+            let isFirstWiFi = $0.keyword!.wholeMatch(of: RegexManager.shared.wifiRegex) != nil
+            let isSecondWiFi = $1.keyword!.wholeMatch(of: RegexManager.shared.wifiRegex) != nil
+            if isFirstWiFi != isSecondWiFi {
+                // Wi-Fi 관련 키워드가 있으면 뒤로 보냄
+                return !isFirstWiFi
+            }
+            return $0.keyword! < $1.keyword!
+        }
+
+        pwBoxes.sort {
+            if $0.keyword! == $1.keyword! {
+                return !$0.content.isEmpty && $1.content.isEmpty
+            }
+            return $0.keyword! < $1.keyword!
+        }
 
         return ExtractedBoxes(idBoxes: idBoxes, pwBoxes: pwBoxes, otherBoxes: otherBoxes)
     }
 
-    private func identifyKeyword(originalText: String, boundingBox: CGRect) -> KeywordBox {
+    private func identifyKeyword(originalText: String, boundingBox: CGRect) -> [KeywordBox] {
+        let regexManager = RegexManager.shared
+        var keywordBoxes: [KeywordBox] = []
 
+        if let match = originalText.wholeMatch(of: regexManager.ktWifiRegex) ??
+                       originalText.wholeMatch(of: regexManager.skWifiRegex) ??
+                       originalText.wholeMatch(of: regexManager.lgWifiRegex) {
+            let value = String(match.1)
+                .trimmingCharacters(in: .whitespaces)
+                .replacing(/[\-.\s]/, with: "_")
+                .replacing(/_+/, with: "_")
+            let valueBox = self.splitBoundingBox(originalBox: boundingBox, splitFactor: CGFloat(1 - Double(String(match.1).count) / Double(originalText.count)))
+
+            keywordBoxes.append(KeywordBox(label: "ID", content: value, contentBox: valueBox, keyword: "", keywordBox: nil))
+
+        } else if let match = originalText.wholeMatch(of: regexManager.idRegex) {
+            let keyword = String(match.1)
+            let value = String(match.2).trimmingCharacters(in: .whitespaces)
+            let valueBox = self.splitBoundingBox(originalBox: boundingBox, splitFactor: CGFloat(1 - Double(String(match.2).count) / Double(originalText.count)))
+            let keywordBox = CGRect(
+                x: boundingBox.minX,
+                y: boundingBox.minY,
+                width: boundingBox.width - valueBox.width,
+                height: boundingBox.height
+            )
+
+            keywordBoxes.append(KeywordBox(label: "ID", content: value, contentBox: valueBox, keyword: keyword, keywordBox: keywordBox))
+        }
+
+        if let match = originalText.wholeMatch(of: regexManager.pwRegex) {
+            let keyword = String(match.1)
+            let value = String(match.2).trimmingCharacters(in: .whitespaces)
+            let valueBox = self.splitBoundingBox(originalBox: boundingBox, splitFactor: CGFloat(1 - Double(String(match.2).count) / Double(originalText.count)))
+            let keywordBox = CGRect(
+                x: boundingBox.minX,
+                y: boundingBox.minY,
+                width: boundingBox.width - valueBox.width,
+                height: boundingBox.height
+            )
+
+            keywordBoxes.append(KeywordBox(label: "PW", content: value, contentBox: valueBox, keyword: keyword, keywordBox: keywordBox))
+        }
+
+        if !keywordBoxes.isEmpty {
+            return keywordBoxes
+        }
+
+
+        /**
         let (keyword, cleanedText, index) = replaceDelimiterAfterKeyword(in: originalText, keywords: idKeywords + pwKeywords)
 
-        // ID or PW 키워드가 없는 경우 처리
-        guard let keyword = keyword else {
-//            Log.print("원본텍스트:\(originalText), 기타텍스트:\(cleanedText)")
-            return KeywordBox(label: "", content: cleanedText, contentBox: boundingBox, labelBox: boundingBox, index: nil)
-        }
-
         // ID or PW 키워드가 있는 경우 처리
-        let value = cleanedText
-        let valueBox = self.splitBoundingBox(originalBox: boundingBox, splitFactor: CGFloat(1 - Double(value.count) / Double(originalText.count)))
+        if let keyword = keyword {
+            let value = cleanedText
+            let valueBox = self.splitBoundingBox(originalBox: boundingBox, splitFactor: CGFloat(1 - Double(value.count) / Double(originalText.count)))
 
-        let keywordBox = CGRect(
-            x: boundingBox.minX,
-            y: boundingBox.minY,
-            width: boundingBox.width - valueBox.width,
-            height: boundingBox.height
-        )
+            let keywordBox = CGRect(
+                x: boundingBox.minX,
+                y: boundingBox.minY,
+                width: boundingBox.width - valueBox.width,
+                height: boundingBox.height
+            )
 
-        // ID와 PW 구분에 따라 처리
-        if idKeywords.contains(keyword) {
-//            Log.print("원본텍스트:\(originalText), 분리된텍스트:'\(keyword)' + '\(value)'")
-            return KeywordBox(label: "ID", content: value, contentBox: valueBox, labelBox: keywordBox, index: index)
+            // ID와 PW 구분에 따라 처리
+            if idKeywords.contains(keyword) {
+                //            Log.print("원본텍스트:\(originalText), 분리된텍스트:'\(keyword)' + '\(value)'")
+                return KeywordBox(label: "ID", content: value, contentBox: valueBox, labelBox: keywordBox, index: index)
 
-        } else if pwKeywords.contains(keyword) {
-//            Log.print("원본텍스트:\(originalText), 분리된텍스트:'\(keyword)' + '\(value)'")
-            return KeywordBox(label: "PW", content: value, contentBox: valueBox, labelBox: keywordBox, index: index)
-        }
-
-        // 컴파일러 요구 사항에 따른 디폴트 반환값
-        return KeywordBox(label: "", content: cleanedText, contentBox: boundingBox, labelBox: boundingBox, index: nil)
-    }
-
-    private func replaceDelimiterAfterKeyword(in text: String, keywords: Array<String>) -> (String?, String, Int?) {
-        // 각 키워드를 순회하며 해당 키워드가 있는 위치를 찾습니다.
-        for (index, keyword) in keywords.enumerated() {
-            if let range = text.range(of: "\\b\(keyword)\\b", options: .regularExpression) {
-                // 키워드 뒤의 텍스트 추출
-                var modifiedSuffix = text[range.upperBound...].trimmingCharacters(in: .whitespaces)
-
-                // 첫 번째 문자가 특수 문자일 경우, 알파벳이나 숫자가 나올 때까지 공백으로 대체
-                while let firstChar = modifiedSuffix.first, ":-._\\/|)]}".contains(firstChar) {
-                    modifiedSuffix.replaceSubrange(modifiedSuffix.startIndex...modifiedSuffix.startIndex, with: " ")
-
-                    modifiedSuffix = modifiedSuffix.trimmingCharacters(in: .whitespaces)
-                }
-                return (keyword, modifiedSuffix.trimmingCharacters(in: .whitespaces), index)
-
+            } else if pwKeywords.contains(keyword) {
+                //            Log.print("원본텍스트:\(originalText), 분리된텍스트:'\(keyword)' + '\(value)'")
+                return KeywordBox(label: "PW", content: value, contentBox: valueBox, labelBox: keywordBox, index: index)
             }
         }
+         */
 
-        // 키워드가 발견되지 않은 경우
-        return (nil, text, nil)
+        // ID or PW 키워드가 없는 경우 처리
+
+        let cleanedText = originalText.trimmingCharacters(in: .whitespaces)
+
+        return [KeywordBox(label: "", content: cleanedText, contentBox: boundingBox, keyword: nil, keywordBox: nil)]
     }
+
+//    private func replaceDelimiterAfterKeyword(in text: String, keywords: Array<String>) -> (String?, String, Int?) {
+//        // 각 키워드를 순회하며 해당 키워드가 있는 위치를 찾습니다.
+//        for (index, keyword) in keywords.enumerated() {
+//            if let range = text.range(of: "\\b\(keyword)\\b", options: .regularExpression) {
+//                // 키워드 뒤의 텍스트 추출
+//                var modifiedSuffix = text[range.upperBound...].trimmingCharacters(in: .whitespaces)
+//
+//                // 첫 번째 문자가 특수 문자일 경우, 알파벳이나 숫자가 나올 때까지 공백으로 대체
+//                while let firstChar = modifiedSuffix.first, ":-._\\/|)]}".contains(firstChar) {
+//                    modifiedSuffix.replaceSubrange(modifiedSuffix.startIndex...modifiedSuffix.startIndex, with: " ")
+//
+//                    modifiedSuffix = modifiedSuffix.trimmingCharacters(in: .whitespaces)
+//                }
+//                return (keyword, modifiedSuffix.trimmingCharacters(in: .whitespaces), index)
+//
+//            }
+//        }
+//
+//        // 키워드가 발견되지 않은 경우
+//        return (nil, text, nil)
+//    }
 
     private func splitBoundingBox(originalBox: CGRect, splitFactor: CGFloat) -> CGRect {
         let newWidth = originalBox.width * (1 - splitFactor)
@@ -285,7 +364,7 @@ public final class DefaultImageAnalysisRepository: ImageAnalysisRepository {
 }
 
 
-
+/**
 public final class QuickImageAnalysisRepository: ImageAnalysisRepository {
     let idKeywords: [String] = ["ssid", "SSID", "ID", "Id", "iD", "id", "I/D", "I.D", "1D", "1.D", "아이디", "1b", "이름", "무선랜 이름", "무선랜이름", "1.0", "10", "Network", "NETWORK", "network", "네트워크",  "WIFI", "Wifi", "WiFi", "wifi", "Wi-Fi", "와이파이"]
     let pwKeywords: [String] = ["PW", "Pw", "pW", "pw", "pass", "Pass", "PASS", "password", "Password", "PASSWORD", "패스워드", "암호", "무선랜 암호", "무선랜암호", "P.W", "PV", "P/W", "P\\A", "P1A", "비밀번호", "비번"]
@@ -578,3 +657,4 @@ public final class QuickImageAnalysisRepository: ImageAnalysisRepository {
         return CGImagePropertyOrientation(rawValue: orientationValue) ?? .up
     }
 }
+ */

--- a/Wasap/Wasap/Features/WifiAutoConnect/Repository/ImageAnalysisRepository.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/Repository/ImageAnalysisRepository.swift
@@ -80,8 +80,10 @@ public final class DefaultImageAnalysisRepository: ImageAnalysisRepository {
         if let firstIDBox = extractedBoxes.idBoxes.first {
             if firstIDBox.content.isEmpty {
                 ssidBox = findClosestRightText(for: extractedBoxes.idBoxes.map { $0.keywordBox ?? $0.contentBox }, in: extractedBoxes.otherBoxes)
+                print("ssid findClosestRightText:\(ssidBox?.1)|| \(ssidBox?.0)||\(extractedBoxes.idBoxes.first?.keyword)||\(extractedBoxes.idBoxes.first?.keywordBox)")
             } else {
                 ssidBox = (firstIDBox.contentBox, firstIDBox.content)
+                print("ssid in!! @first: \(ssidBox?.1)")
             }
         }
 
@@ -89,26 +91,32 @@ public final class DefaultImageAnalysisRepository: ImageAnalysisRepository {
         if let firstPWBox = extractedBoxes.pwBoxes.first {
             if firstPWBox.content.isEmpty {
                 passwordBox = findClosestRightText(for: extractedBoxes.pwBoxes.map { $0.keywordBox ?? $0.contentBox }, in: extractedBoxes.otherBoxes)
+                print("pass findClosestRightText: \(passwordBox?.1)|| \(passwordBox?.0)||\(extractedBoxes.pwBoxes.first?.keyword)||\(extractedBoxes.pwBoxes.first?.keywordBox)")
             } else {
                 passwordBox = (firstPWBox.contentBox, firstPWBox.content)
+                print("pass in!! @first: \(passwordBox?.1)")
             }
         } else if ssidBox != nil && ssidBox?.1 != "" {
             passwordBox = findClosestBelowText(for: [ssidBox!.0], in: extractedBoxes.otherBoxes)
-            print("other:\(extractedBoxes.otherBoxes.first?.1)")
-            print("🐰ssidBox1:\(ssidBox?.1)")
-            print("🐰ssidBox0:\(ssidBox?.0)")
-            print("🥝passwordBox:\(passwordBox?.1)")
+            print("pass findClosestBelowText in ssid O & pass X @first: \(passwordBox?.1)")
+//            print("other:\(extractedBoxes.otherBoxes.first?.1)")
+//            print("🐰ssidBox1:\(ssidBox?.1)")
+//            print("🐰ssidBox0:\(ssidBox?.0)")
+//            print("🥝passwordBox:\(passwordBox?.1)")
         }
 
         // 2. ID(또는 PW) key와 value가 세로로 나란한 경우
         if (ssidBox == nil) || (ssidBox?.1 == "") {
             ssidBox = findClosestBelowText(for: extractedBoxes.idBoxes.map { $0.keywordBox ?? $0.contentBox }, in: extractedBoxes.otherBoxes)
+            print("ssid findClosestBelowText: \(ssidBox?.1)")
         }
         if (passwordBox == nil) || (passwordBox?.1 == "") {
             passwordBox = findClosestBelowText(for: extractedBoxes.pwBoxes.map { $0.keywordBox ?? $0.contentBox }, in: extractedBoxes.otherBoxes)
+            print("pass findClosestBelowText: \(passwordBox?.1)")
             if let ssidBox = ssidBox {
                 if (passwordBox == nil || passwordBox?.1 == "") && ssidBox.1 != "" {
                     passwordBox = findClosestBelowText(for: [ssidBox.0], in: extractedBoxes.otherBoxes)
+                    print("pass findClosestBelowText in ssid O & pass X @Last: \(passwordBox?.1)")
                 }
             }
         }
@@ -292,7 +300,6 @@ public final class DefaultImageAnalysisRepository: ImageAnalysisRepository {
 
     private func findClosestRightText(for sourceBoxes: [CGRect], in otherBoxes: [(CGRect, String)]) -> (CGRect, String)? {
         guard let sourceBox = sourceBoxes.first else { return nil }
-
         let yWeight: CGFloat = 1.0
 
         var closestRightText: String = ""

--- a/Wasap/Wasap/Features/WifiAutoConnect/Repository/ImageAnalysisRepository.swift
+++ b/Wasap/Wasap/Features/WifiAutoConnect/Repository/ImageAnalysisRepository.swift
@@ -14,8 +14,6 @@ public protocol ImageAnalysisRepository {
 }
 
 public final class DefaultImageAnalysisRepository: ImageAnalysisRepository {
-//    let idKeywords: [String] = ["ssid", "SSID", "ID", "Id", "iD", "id", "I/D", "I.D", "1D", "1.D", "아이디", "1b", "이름", "무선랜 이름", "무선랜이름", "1.0", "10", "Network", "NETWORK", "network", "네트워크",  "WIFI", "Wifi", "WiFi", "wifi", "Wi-Fi", "와이파이"]
-//    let pwKeywords: [String] = ["PW", "Pw", "pW", "pw", "pass", "Pass", "PASS", "password", "Password", "PASSWORD", "패스워드", "암호", "무선랜 암호", "무선랜암호", "P.W", "PV", "P/W", "P\\A", "P1A", "비밀번호", "비번"]
 
     public init() {}
 
@@ -99,10 +97,6 @@ public final class DefaultImageAnalysisRepository: ImageAnalysisRepository {
         } else if ssidBox != nil && ssidBox?.1 != "" {
             passwordBox = findClosestBelowText(for: [ssidBox!.0], in: extractedBoxes.otherBoxes)
             print("pass findClosestBelowText in ssid O & pass X @first: \(passwordBox?.1)")
-//            print("other:\(extractedBoxes.otherBoxes.first?.1)")
-//            print("🐰ssidBox1:\(ssidBox?.1)")
-//            print("🐰ssidBox0:\(ssidBox?.0)")
-//            print("🥝passwordBox:\(passwordBox?.1)")
         }
 
         // 2. ID(또는 PW) key와 value가 세로로 나란한 경우
@@ -161,9 +155,6 @@ public final class DefaultImageAnalysisRepository: ImageAnalysisRepository {
                 }
             }
         }
-
-//        idBoxes.sort { $0.keyword! < $1.keyword! }
-//        pwBoxes.sort { $0.keyword! < $1.keyword! }
 
         idBoxes.sort {
             if $0.keyword! == $1.keyword! {
@@ -235,36 +226,7 @@ public final class DefaultImageAnalysisRepository: ImageAnalysisRepository {
             return keywordBoxes
         }
 
-
-        /**
-        let (keyword, cleanedText, index) = replaceDelimiterAfterKeyword(in: originalText, keywords: idKeywords + pwKeywords)
-
-        // ID or PW 키워드가 있는 경우 처리
-        if let keyword = keyword {
-            let value = cleanedText
-            let valueBox = self.splitBoundingBox(originalBox: boundingBox, splitFactor: CGFloat(1 - Double(value.count) / Double(originalText.count)))
-
-            let keywordBox = CGRect(
-                x: boundingBox.minX,
-                y: boundingBox.minY,
-                width: boundingBox.width - valueBox.width,
-                height: boundingBox.height
-            )
-
-            // ID와 PW 구분에 따라 처리
-            if idKeywords.contains(keyword) {
-                //            Log.print("원본텍스트:\(originalText), 분리된텍스트:'\(keyword)' + '\(value)'")
-                return KeywordBox(label: "ID", content: value, contentBox: valueBox, labelBox: keywordBox, index: index)
-
-            } else if pwKeywords.contains(keyword) {
-                //            Log.print("원본텍스트:\(originalText), 분리된텍스트:'\(keyword)' + '\(value)'")
-                return KeywordBox(label: "PW", content: value, contentBox: valueBox, labelBox: keywordBox, index: index)
-            }
-        }
-         */
-
         // ID or PW 키워드가 없는 경우 처리
-
         let cleanedText = originalText.trimmingCharacters(in: .whitespaces)
 
         return [KeywordBox(label: "", content: cleanedText, contentBox: boundingBox, keyword: nil, keywordBox: nil)]

--- a/Wasap/Wasap/Utility/RegexManager.swift
+++ b/Wasap/Wasap/Utility/RegexManager.swift
@@ -61,6 +61,7 @@ final class RegexManager {
                         #/\(?KEY\)?/#
                         #/암호키/#
                         #/암호/#
+                        #/Zone|zone|ZONE/#
                     }
                 }
             }

--- a/Wasap/Wasap/Utility/RegexManager.swift
+++ b/Wasap/Wasap/Utility/RegexManager.swift
@@ -8,23 +8,10 @@
 import Foundation
 import RegexBuilder
 
-final class RegexManager {
-    static let shared = RegexManager()
-
-    // MARK: - Regex Patterns
-    let idRegex: Regex<(Substring, Substring, Substring)>
-    let pwRegex: Regex<(Substring, Substring, Substring)>
-
-    let ktWifiRegex: Regex<(Substring, Substring)>
-    let skWifiRegex: Regex<(Substring, Substring)>
-    let lgWifiRegex: Regex<(Substring, Substring)>
-
-    let wifiRegex: Regex<Substring>
-
-    // MARK: - Initialization
-    private init() {
-
-        idRegex = Regex {
+extension Regex where Output == (Substring, Substring, Substring) {
+    /// ID 관련 키워드 매칭
+    public static var idRegex: Regex<RegexOutput> {
+        Regex {
             Optionally {
                 ChoiceOf {
                     #/\(?[Ww][Ii][-_]?[Ff][Ii]\)?/#
@@ -88,8 +75,11 @@ final class RegexManager {
                 ZeroOrMore(.any)
             }
         }
+    }
 
-        pwRegex = Regex {
+    /// PW 관련 키워드 매칭
+    public static var pwRegex: Regex<RegexOutput> {
+        Regex {
             Optionally {
                 ChoiceOf {
                     #/\(?[Ww][Ii][-_]?[Ff][Ii]\)?/#
@@ -124,8 +114,13 @@ final class RegexManager {
                 #/[•\-\s]*/#
             }
         }
+    }
+}
 
-        ktWifiRegex = Regex {
+extension Regex where Output == (Substring, Substring) {
+    /// KT 통신사 SSID 매칭
+    public static var ktWifiRegex: Regex<RegexOutput> {
+        Regex {
             ZeroOrMore(.any, .reluctant)
             Capture {
                 "KT"
@@ -153,8 +148,11 @@ final class RegexManager {
                 ZeroOrMore(.any)
             }
         }
+    }
 
-        skWifiRegex = Regex {
+    /// SKT 통신사 SSID 매칭
+    public static var skWifiRegex: Regex<RegexOutput> {
+        Regex {
             ZeroOrMore(.any, .reluctant)
             Capture {
                 "SK"
@@ -166,8 +164,11 @@ final class RegexManager {
                 ZeroOrMore(.any)
             }
         }
+    }
 
-        lgWifiRegex = Regex {
+    /// LG UPlus 통신사 SSID 매칭
+    public static var lgWifiRegex: Regex<RegexOutput> {
+        Regex {
             ZeroOrMore(.any, .reluctant)
             Capture {
                 "U+"
@@ -176,9 +177,11 @@ final class RegexManager {
                 ZeroOrMore(.any)
             }
         }
-
-        wifiRegex = #/\(?[Ww][Ii1Í]\s?[-_]?\s?[Fft][Ii1Í]\)?/#
-
     }
 }
 
+extension Regex where Output == Substring {
+    public static var wifiRegex: Regex<RegexOutput> {
+        #/\(?[Ww][Ii1Í]\s?[-_]?\s?[Fft][Ii1Í]\)?/#
+    }
+}

--- a/Wasap/Wasap/Utility/RegexManager.swift
+++ b/Wasap/Wasap/Utility/RegexManager.swift
@@ -1,0 +1,183 @@
+//
+//  RegexManager.swift
+//  Wasap
+//
+//  Created by Chang Jonghyeon on 12/3/24.
+//
+
+import Foundation
+import RegexBuilder
+
+final class RegexManager {
+    static let shared = RegexManager()
+
+    // MARK: - Regex Patterns
+    let idRegex: Regex<(Substring, Substring, Substring)>
+    let pwRegex: Regex<(Substring, Substring, Substring)>
+
+    let ktWifiRegex: Regex<(Substring, Substring)>
+    let skWifiRegex: Regex<(Substring, Substring)>
+    let lgWifiRegex: Regex<(Substring, Substring)>
+
+    let wifiRegex: Regex<Substring>
+
+    // MARK: - Initialization
+    private init() {
+
+        idRegex = Regex {
+            Optionally {
+                ChoiceOf {
+                    #/\(?[Ww][Ii][-_]?[Ff][Ii]\)?/#
+                    #/무선랜/#
+                    #/와이파이/#
+                    #/FREE|Free|free/#
+                    #/무료/#
+                }
+                #/[:\-._\\/|)\]}\s]*/#
+            }
+            #/[•\s]*/#
+            Capture {
+                ChoiceOf {
+                    #/\(?[Ss][Ss][Ii][Dd]\)?/#
+                    #/\(?[Ii1][I1|\\./∙\s]?[Dd]\)?/#
+                    #/아이디/#
+                    #/무선랜 이름/#
+                    #/명/#
+                    #/이름/#
+                    #/\(?[Nn][Ee][Tt][Ww][Oo][Rr][Kk]\)?/#
+                    #/네트워크/#
+                    #/\(?[Ww][Ii1Í]\s?[-_]?\s?[Fft][Ii1Í]\)?/#
+                    #/와이파이/#
+                }
+                NegativeLookahead {
+                    #/[-\s]*/#
+                    ChoiceOf {
+                        #/\(?[Pp][./∙\s]?[Ww]\)?/#
+                        #/\(?[Pp][Aa][Ss]{2}[Ww][Oo][Rr][Dd]\)?/#
+                        #/\(?[Pp][Aa][Ss]{2}\)?/#
+                        #/비밀번호/#
+                        #/패스워드/#
+                        #/비번/#
+                        #/\(?KEY\)?/#
+                        #/암호키/#
+                        #/암호/#
+                    }
+                }
+            }
+            ZeroOrMore(.whitespace)
+            Optionally {
+                #/[:;\-._\\/|)\]}]/#
+            }
+            ZeroOrMore(.whitespace)
+            Capture {
+                ZeroOrMore(.any, .reluctant)
+            }
+            Optionally {
+                ChoiceOf {
+                    #/\(?[Pp][./∙\s]?[Ww]\)?/#
+                    #/\(?[Pp][Aa][Ss]{2}[Ww][Oo][Rr][Dd]\)?/#
+                    #/\(?[Pp][Aa][Ss]{2}\)?/#
+                    #/비밀번호/#
+                    #/패스워드/#
+                    #/비번/#
+                    #/\(?KEY\)?/#
+                    #/암호키/#
+                    #/암호/#
+                }
+                ZeroOrMore(.any)
+            }
+        }
+
+        pwRegex = Regex {
+            Optionally {
+                ChoiceOf {
+                    #/\(?[Ww][Ii][-_]?[Ff][Ii]\)?/#
+                    #/무선랜/#
+                    #/와이파이/#
+                }
+                #/[:\-._\\/|)\]}\s]*/#
+            }
+            ZeroOrMore(.any, .reluctant)
+            Capture {
+                ChoiceOf {
+                    #/\(?[Pp][./∙\s]?[Ww]\)?/#
+                    #/\(?[Pp][Aa][Ss]{2}[Ww][Oo][Rr][Dd]\)?/#
+                    #/\(?[Pp][Aa][Ss]{2}\)?/#
+                    #/비밀번호/#
+                    #/패스워드|파스워드/#
+                    #/비번/#
+                    #/\(?KEY\)?/#
+                    #/암호키/#
+                    #/암호/#
+                }
+            }
+            ZeroOrMore(.whitespace)
+            Optionally {
+                #/[:;\-._\\/|)\]}]/#
+            }
+            ZeroOrMore(.whitespace)
+            Capture {
+                ZeroOrMore(.any, .reluctant)
+            }
+            Optionally {
+                #/[•\-\s]*/#
+            }
+        }
+
+        ktWifiRegex = Regex {
+            ZeroOrMore(.any, .reluctant)
+            Capture {
+                "KT"
+                #/[\-._\s]*/#
+                #/GIGA|GiGA/#
+                #/[\-._\s]*/#
+                Optionally {
+                    #/5G|2G/#
+                    #/[\-._\s]*/#
+                }
+                ZeroOrMore(.any, .reluctant)
+            }
+            Optionally {
+                ChoiceOf {
+                    #/\(?[Pp][./∙\s]?[Ww]\)?/#
+                    #/\(?[Pp][Aa][Ss]{2}[Ww][Oo][Rr][Dd]\)?/#
+                    #/\(?[Pp][Aa][Ss]{2}\)?/#
+                    #/비밀번호/#
+                    #/패스워드/#
+                    #/비번/#
+                    #/\(?KEY\)?/#
+                    #/암호키/#
+                    #/암호/#
+                }
+                ZeroOrMore(.any)
+            }
+        }
+
+        skWifiRegex = Regex {
+            ZeroOrMore(.any, .reluctant)
+            Capture {
+                "SK"
+                #/[\-._\s]*/#
+                #/WIFI|WiFi|Wifi/#
+                Optionally {
+                    #/GIGA|GiGA/#
+                }
+                ZeroOrMore(.any)
+            }
+        }
+
+        lgWifiRegex = Regex {
+            ZeroOrMore(.any, .reluctant)
+            Capture {
+                "U+"
+                #/\s*/#
+                #/Net|NET|Zone|zone|ZONE/#
+                ZeroOrMore(.any)
+            }
+        }
+
+        wifiRegex = #/\(?[Ww][Ii1Í]\s?[-_]?\s?[Fft][Ii1Í]\)?/#
+
+    }
+}
+

--- a/Wasap/WasapTests/WifiAutoConnect/UseCase/ImageAnalysisUseCaseTests.swift
+++ b/Wasap/WasapTests/WifiAutoConnect/UseCase/ImageAnalysisUseCaseTests.swift
@@ -51,8 +51,8 @@ class ImageAnalysisUseCaseTests {
     let bundle: Bundle
     
     init() {
-//        repository = DefaultImageAnalysisRepository()
-        repository = QuickImageAnalysisRepository()
+        repository = DefaultImageAnalysisRepository()
+//        repository = QuickImageAnalysisRepository()
         useCase = DefaultImageAnalysisUseCase(imageAnalysisRepository: repository)
         bundle = Bundle(for: type(of: self))
     }

--- a/Wasap/WasapTests/WifiAutoConnect/UseCase/WifiConnectUseCaseTests.swift
+++ b/Wasap/WasapTests/WifiAutoConnect/UseCase/WifiConnectUseCaseTests.swift
@@ -55,6 +55,10 @@ class MockWifiConnectRepository: WiFiConnectRepository {
     func getCurrentWiFiSSID() -> RxSwift.Single<String?> {
         return .just(nil)
     }
+
+    func getConnectedSSID() -> String? {
+        return nil
+    }
 }
 
 class MockWiFiConnectUseCase: WiFiConnectUseCase {
@@ -66,6 +70,10 @@ class MockWiFiConnectUseCase: WiFiConnectUseCase {
     
     func connectToWiFi(ssid: String, password: String) -> Single<Bool> {
         return repository.connectToWiFi(ssid: ssid, password: password)
+    }
+
+    func getConnectedSSID() -> String? {
+        return nil
     }
 }
 


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
SSID/PW 키워드를 하드코딩으로 인식했던 기존 로직을 Regex로 판별하도록 수정하였습니다.
통신사 기본 SSID를 사용하는 케이스, 그리고 키워드는 없으나 전형적인 세로 배치를 이룬 와이파이 안내판에 대한 대응을 도입하였습니다.
이로써 기존 OCR 대응 범위를 확장하였습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : resolved #77 


## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
한글 인식도 동일한 Regex 정규표현식으로 구현 완료하였으나, 속도를 절반으로 줄이기 위해 주석처리하였습니다.
보다 개선된 성능 및 동시성을 도입하여 차후 한영 대응을 도입하고자 합니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->


https://github.com/user-attachments/assets/b74c3dec-cf46-4f5c-b73c-3335903f5fce



## 🔥 Test
<!-- Test -->

